### PR TITLE
feat(content): add a custom variable to set custom content provider

### DIFF
--- a/simpleclip.el
+++ b/simpleclip.el
@@ -195,6 +195,15 @@
   :type 'boolean
   :group 'simpleclip)
 
+(defcustom simpleclip-custom-content-provider nil
+   "Custom program to provide clipboard content.
+
+If nil, use default logic to get clipboard content according to OS.
+
+If non nil, use the output of executing the provider program as clipboard content "
+   :type 'string
+   :group 'simpleclip)
+
 ;;;###autoload
 (defgroup simpleclip-keys nil
   "Key bindings for `simpleclip-mode'."
@@ -319,46 +328,48 @@ in GNU Emacs 24.1 or higher."
 ;;;###autoload
 (defun simpleclip-get-contents ()
   "Return the contents of the system clipboard as a string."
-  (condition-case nil
-      (cond
-        ((fboundp 'ns-get-pasteboard)
-         (ns-get-pasteboard))
-        ((fboundp 'w32-get-clipboard-data)
-         (or (w32-get-clipboard-data)
-             simpleclip-contents))
-        ((and (featurep 'mac)
-              (fboundp 'gui-get-selection))
-         (gui-get-selection 'CLIPBOARD 'NSStringPboardType))
-        ((and (featurep 'mac)
-              (fboundp 'x-get-selection))
-         (x-get-selection 'CLIPBOARD 'NSStringPboardType))
-        ;; todo, this should try more than one request type, as in gui--selection-value-internal
-        ((fboundp 'gui-get-selection)
-         (gui-get-selection 'CLIPBOARD (or x-select-request-type 'UTF8_STRING)))
-        ;; todo, this should try more than one request type, as in gui--selection-value-internal
-        ((fboundp 'x-get-selection)
-         (x-get-selection 'CLIPBOARD (or x-select-request-type 'UTF8_STRING)))
-        (t
-         (error "Clipboard support not available")))
-    (error
-     (condition-case nil
-         (cond
-           ((eq system-type 'darwin)
-            (with-output-to-string
-              (with-current-buffer standard-output
-                (call-process "/usr/bin/pbpaste" nil t nil "-Prefer" "txt"))))
-           ((eq system-type 'cygwin)
-            (with-output-to-string
-              (with-current-buffer standard-output
-                (call-process "getclip" nil t nil))))
-           ((memq system-type '(gnu gnu/linux gnu/kfreebsd))
-            (with-output-to-string
-              (with-current-buffer standard-output
-                (call-process "xsel" nil t nil "--clipboard" "--output"))))
-           (t
-            (error "Clipboard support not available")))
-       (error
-        (error "Clipboard support not available"))))))
+  (if simpleclip-custom-content-provider
+      (shell-command-to-string simpleclip-custom-content-provider)
+    (condition-case nil
+        (cond
+         ((fboundp 'ns-get-pasteboard)
+          (ns-get-pasteboard))
+         ((fboundp 'w32-get-clipboard-data)
+          (or (w32-get-clipboard-data)
+              simpleclip-contents))
+         ((and (featurep 'mac)
+               (fboundp 'gui-get-selection))
+          (gui-get-selection 'CLIPBOARD 'NSStringPboardType))
+         ((and (featurep 'mac)
+               (fboundp 'x-get-selection))
+          (x-get-selection 'CLIPBOARD 'NSStringPboardType))
+         ;; todo, this should try more than one request type, as in gui--selection-value-internal
+         ((fboundp 'gui-get-selection)
+          (gui-get-selection 'CLIPBOARD (or x-select-request-type 'UTF8_STRING)))
+         ;; todo, this should try more than one request type, as in gui--selection-value-internal
+         ((fboundp 'x-get-selection)
+          (x-get-selection 'CLIPBOARD (or x-select-request-type 'UTF8_STRING)))
+         (t
+          (error "Clipboard support not available")))
+      (error
+       (condition-case nil
+           (cond
+            ((eq system-type 'darwin)
+             (with-output-to-string
+               (with-current-buffer standard-output
+                 (call-process "/usr/bin/pbpaste" nil t nil "-Prefer" "txt"))))
+            ((eq system-type 'cygwin)
+             (with-output-to-string
+               (with-current-buffer standard-output
+                 (call-process "getclip" nil t nil))))
+            ((memq system-type '(gnu gnu/linux gnu/kfreebsd))
+             (with-output-to-string
+               (with-current-buffer standard-output
+                 (call-process "xsel" nil t nil "--clipboard" "--output"))))
+            (t
+             (error "Clipboard support not available")))
+         (error
+          (error "Clipboard support not available")))))))
 
 ;;;###autoload
 (defun simpleclip-set-contents (str-val)


### PR DESCRIPTION
Use the output of executing the provider program as clipboard content
if simpleclip-custom-content-provider is set.

This feature can also be a workaround for #6 