### PR TITLE
Changing (require 'cl) to (require 'cl-lib)

### DIFF
--- a/simpleclip.el
+++ b/simpleclip.el
@@ -158,7 +158,7 @@
 ;;; requirements
 
 ;; for callf, assert
-(require 'cl)
+(require 'cl-lib)
 
 (autoload 'term-send-raw-string "term")
 


### PR DESCRIPTION
Emacs 28 compiled from source on MacOS is giving me a deprecation warning at startup. Editing the file that way got me rid of the warning `Package cl deprecated`