### PR TITLE
Make sure 'simpleclip-custom-content-provider is non-nil before using it.

### DIFF
--- a/simpleclip.el
+++ b/simpleclip.el
@@ -325,6 +325,7 @@ in GNU Emacs 24.1 or higher."
        ((and (fboundp 'window-system) (window-system)
         (or
           (and (boundp 'simpleclip-custom-content-provider)
+               simpleclip-custom-content-provider
             (shell-command-to-string simpleclip-custom-content-provider))
           (and (fboundp 'ns-get-pasteboard)
             (ns-get-pasteboard))


### PR DESCRIPTION
Fixes an issue introduced in #15.

Before this fix `'simpleclip-custom-content-provider` was always used because it only checked that the variable was bound instead of checking for a non-nil value.

```
(boundp 'simpleclip-custom-content-provider)
;; t
simpleclip-custom-content-provider
;; nil
```

This resulted in always running an empty shell command.

A cleaner way might to be to only check for a non-nil value since if it's non-nil, `'bound-p` will return true.