### PR TITLE
fix: On macos, emacs gui simpleclip-paste only insert empty string due to wrong data-type

### DIFF
--- a/simpleclip.el
+++ b/simpleclip.el
@@ -340,10 +340,10 @@ in GNU Emacs 24.1 or higher."
             (x-get-selection 'CLIPBOARD 'NSStringPboardType))
           ;; todo, this should try more than one request type, as in gui--selection-value-internal
           (and (fboundp 'gui-get-selection)
-            (gui-get-selection 'CLIPBOARD (or x-select-request-type 'UTF8_STRING)))
+            (gui-get-selection 'CLIPBOARD (car x-select-request-type)))
           ;; todo, this should try more than one request type, as in gui--selection-value-internal
           (and (fboundp 'x-get-selection)
-            (x-get-selection 'CLIPBOARD (or x-select-request-type 'UTF8_STRING))))))
+            (x-get-selection 'CLIPBOARD (car x-select-request-type))))))
        (t
         (error "Clipboard support not available")))
     (error


### PR DESCRIPTION
When x-select-request-type is nil, gui-get-selection's argument(data-type) is
STRING by default.Setting to UTF8_STRING, only paste empty string in mac-gui.