### PR TITLE
Add wayland support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,6 +8,7 @@ Simplified access to the system clipboard in Emacs.
  * [Explanation](#explanation)
  * [Keybindings](#keybindings)
  * [Notes](#notes)
+ * [Wayland](#wayland)
  * [Compatibility and Requirements](#compatibility-and-requirements)
 
 ## Quickstart
@@ -83,8 +84,12 @@ The following functions may be useful to call from Lisp:
 	simpleclip-get-contents
 	simpleclip-set-contents
 
+## Wayland
+
+[wl-clipboard](https://github.com/bugaevc/wl-clipboard) is used on Wayland systems to interact with system clipboard.
+
 ## Compatibility and Requirements
 
 No external dependencies
 
-Tested on OS X, X11, and MS Windows
+Tested on OS X, X11, Wayland and MS Windows

--- a/simpleclip.el
+++ b/simpleclip.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t; -*-
 ;;; simpleclip.el --- Simplified access to the system clipboard
 ;;
 ;; Copyright (c) 2012-2020 Roland Walker
@@ -192,7 +193,8 @@
 
 If nil, use default logic to get clipboard content according to OS.
 
-If non-nil, use the output of executing the provider program as clipboard content."
+If non-nil, use the output of executing the provider program
+as clipboard content."
    :type 'string
    :group 'simpleclip)
 
@@ -422,7 +424,7 @@ if the argument is positive and otherwise disables the mode.
 
 When called from Lisp, this command enables the mode if the
 argument is omitted or nil, and toggles the mode if the argument
-is 'toggle."
+is \\='toggle."
   :group 'simpleclip
   :global t
   (cond

--- a/simpleclip.el
+++ b/simpleclip.el
@@ -360,7 +360,9 @@ in GNU Emacs 24.1 or higher."
           ((memq system-type '(gnu gnu/linux gnu/kfreebsd))
            (with-output-to-string
              (with-current-buffer standard-output
-               (call-process "xsel" nil t nil "--clipboard" "--output"))))
+               (if (string= (getenv "XDG_SESSION_TYPE") "wayland")
+                   (call-process "wl-paste" nil t nil)
+                 (call-process "xsel" nil t nil "--clipboard" "--output")))))
           (t
            (error "Clipboard support not available")))
        (error
@@ -400,7 +402,9 @@ in GNU Emacs 24.1 or higher."
            ((memq system-type '(gnu gnu/linux gnu/kfreebsd))
             (with-temp-buffer
               (insert str-val)
-              (call-process-region (point-min) (point-max) "xsel" nil nil nil "--clipboard" "--input")))
+               (if (string= (getenv "XDG_SESSION_TYPE") "wayland")
+                  (call-process "wl-copy" nil t nil)
+                (call-process-region (point-min) (point-max) "xsel" nil nil nil "--clipboard" "--input"))))
            (t
             (error "Clipboard support not available")))
        (error


### PR DESCRIPTION
`xsel` is it not working on wayland. [wl-clipboard](https://github.com/bugaevc/wl-clipboard) is a good replacement.

Tested on my Fedora 42 kde wayland.